### PR TITLE
Installation of the packages to run the simulations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,36 @@
-Simulation software used to generate data reported on Figure 3 of [BCGMRY]
+# Simulation software used to generate data reported on Figure 3 of [BCGMRY]
 
-The simulation software consists of two python scripts:
+## The simulation software consists of two python scripts:
 
-decoder_setup.py is the offline part of the decoder that constructs check matrices,
+* `decoder_setup.py` is the offline part of the decoder that constructs check matrices,
 syndrome measurement circuits, and decoding matrices for a particular quantum code.
 This computation can take a few minutes per code. All code data is saved to disk.
 One has to call decoder_setup.py only once for each combination (code, error rate, number of syndrome cycles). 
 
-decoder_run.py is the online part of the decoder that simulates error correction circuits. It relies on the software implementation of the Belief Propagation with the Ordered Statistics Decoder due to 
+* `decoder_run.py` is the online part of the decoder that simulates error correction circuits. It relies on the software implementation of the Belief Propagation with the Ordered Statistics Decoder due to 
 Joschka Roffe
 "LDPC: Python tools for low density parity check codes"
 https://pypi.org/project/ldpc/
 
-File naming: the working directory that contains  decoder_setup.py and decoder_run.py must contain folders "TMP" and "CODE_n_k_d" for each code [[n,k,d]] to be simulated. Initially these folders are empty. Folder "TMP" stores code data files with
-check matrices, syndrome measurement circuits, and decoding matrices. There is a separate data file for each combination (code, error rate, number of syndrome cycles). Create code data files using decoder_setup.py. Folder "CODE_n_k_d" contains a file "result" that stores the simulation results. Each line in the "result" file has four columns:
-column 1: physical error rate,
-column 2: number of syndrome cycles,
-column 3: number of Monte Carlo trials,
-column 4: number of failed trials that resulted in a logical error.
-Each trial runs the noisy error correction circuit followed by a noiseless syndrome measurement of all stabilizers, decoding, and error correction. A trial is failed if error correction results in a non-identity logical Pauli error. Create "result" files using decoder_run.py
+### File naming
+- the working directory that contains `decoder_setup.py` and `decoder_run.py` must 
+contain folders "TMP" and "CODE_n_k_d" for each code [[n,k,d]] to be simulated. Initially these folders are empty.
+- Folder "TMP" stores code data files with check matrices, syndrome measurement circuits, and decoding matrices.
+- There is a separate data file for each combination (code, error rate, number of syndrome cycles). 
+- Create code data files using `decoder_setup.py`
+- Folder "CODE_n_k_d" contains a file `result` that stores the simulation results.
 
-distance_test.py calculates the code distance by solving an integer linear program
+Each line in the `result` file has four columns:
+- column 1: physical error rate,
+- column 2: number of syndrome cycles,
+- column 3: number of Monte Carlo trials,
+- column 4: number of failed trials that resulted in a logical error.
+
+Each trial runs the noisy error correction circuit followed by a noiseless syndrome measurement of all stabilizers, decoding, and error correction. A trial is failed if error correction results in a non-identity logical Pauli error.
+
+Create `result` files using `decoder_run.py`
+
+`distance_test.py` calculates the code distance by solving an integer linear program.
 
 
 [BCGMRY]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Simulation software used to generate data reported on Figure 3 of [BCGMRY]
 
-## The simulation software consists of two python scripts:
+## The simulation software consists of two python scripts
 
 * `decoder_setup.py` is the offline part of the decoder that constructs check matrices,
 syndrome measurement circuits, and decoding matrices for a particular quantum code.

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@ python3.10 -m venv venvs
 source venv/bin/activate
 
 pip install cython==0.29.37
-pip install wheels
+pip install wheel
 pip install numpy==1.22.0
 pip install scipy==1.8.0
 pip install git+https://github.com/quantumgizmos/ldpc.git --no-build-isolation

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,9 @@
+python3.10 -m venv venv
+source venv/bin/activate
+
+pip install cython==0.29.37
+pip install wheels
+pip install numpy==1.22.0
+pip install scipy==1.8.0
+pip install git+https://github.com/quantumgizmos/ldpc.git --no-build-isolation
+pip install git+https://github.com/quantumgizmos/bp_osd.git

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 # This script assumes Python3.10 or later (replace if needed)
 # The script is creating a virtualenv and installing the packages needed to get the ldpcv1 library working
 
-python3.10 -m venv venvs
+python3.10 -m venv venv
 source venv/bin/activate
 
 pip install cython==0.29.37

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,7 @@
-python3.10 -m venv venv
+# This script assumes Python3.10 or later (replace if needed)
+# The script is creating a virtualenv and installing the packages needed to get the ldpcv1 library working
+
+python3.10 -m venv venvs
 source venv/bin/activate
 
 pip install cython==0.29.37


### PR DESCRIPTION
The code in the repository is based on ldpc v1. In order to compile ldpc v1 from sources, an older Cython is needed, which means older scipy and numpy are a requirement too.

* The `install.sh` addresses the installation issues.
* Tested with Python3.10  on Apple Silicon and Amd64.
* It creates a virtual environment and installs the packages. Not sure why it did not work with a `requirements.txt` file.

